### PR TITLE
Require login before quoting or paying

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import './App.css';
 import Home from './Home';
 import Carrito from './Carrito';
 import Login from './Login'; // ✅ Importar Login
+import Pago from './Pago';
 
 function App() {
   return (
@@ -22,6 +23,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/carrito" element={<Carrito />} />
         <Route path="/login" element={<Login />} /> {/* ✅ Ruta funcional */}
+        <Route path="/pago" element={<Pago />} />
       </Routes>
     </div>
   );

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -1,25 +1,26 @@
-import { useState } from 'react';
+import { useState, useContext } from 'react';
+import { AuthContext } from './context/AuthContext';
 import './Login.css';
 
 function Login() {
+  const { usuario, login } = useContext(AuthContext);
   const [correo, setCorreo] = useState('');
   const [clave, setClave] = useState('');
-  const [logueado, setLogueado] = useState(false);
 
   const handleSubmit = (e) => {
     e.preventDefault();
 
     // Aquí podrías validar credenciales contra un backend más adelante
     if (correo && clave) {
-      setLogueado(true);
+      login(correo);
     }
   };
 
-  if (logueado) {
+  if (usuario) {
     return (
       <section className="login-container">
         <h2>Bienvenido</h2>
-        <p>Has iniciado sesión correctamente como <strong>{correo}</strong>.</p>
+        <p>Has iniciado sesión correctamente como <strong>{usuario}</strong>.</p>
       </section>
     );
   }

--- a/src/Pago.jsx
+++ b/src/Pago.jsx
@@ -1,13 +1,24 @@
 import { useContext, useState } from 'react';
 import { CarritoContext } from './context/CarritoContext';
+import { AuthContext } from './context/AuthContext';
 import './Pago.css'; // crea este archivo si quieres estilos personalizados
 
 function Pago() {
+  const { usuario } = useContext(AuthContext);
   const { carrito, vaciarCarrito } = useContext(CarritoContext);
   const [nombre, setNombre] = useState('');
   const [direccion, setDireccion] = useState('');
-  const [correo, setCorreo] = useState('');
+  const [correo, setCorreo] = useState(usuario || '');
   const [pedidoEnviado, setPedidoEnviado] = useState(false);
+
+  if (!usuario) {
+    return (
+      <section style={{ padding: '2rem' }}>
+        <h2>Proceso de Pago</h2>
+        <p>Debes iniciar sesión para completar el pago.</p>
+      </section>
+    );
+  }
 
   const total = carrito.reduce((acc, item) => acc + item.precio * item.cantidad, 0);
 
@@ -47,7 +58,13 @@ function Pago() {
         <input type="text" value={direccion} onChange={(e) => setDireccion(e.target.value)} required />
 
         <label>Correo electrónico:</label>
-        <input type="email" value={correo} onChange={(e) => setCorreo(e.target.value)} required />
+        <input
+          type="email"
+          value={correo}
+          onChange={(e) => setCorreo(e.target.value)}
+          required
+          readOnly={!!usuario}
+        />
 
         <button type="submit">Confirmar Pedido</button>
       </form>

--- a/src/QuoteForm.jsx
+++ b/src/QuoteForm.jsx
@@ -1,11 +1,13 @@
-import { useState } from 'react';
+import { useState, useContext } from 'react';
+import { AuthContext } from './context/AuthContext';
 import './QuoteForm.css';
 
 function QuoteForm() {
+  const { usuario } = useContext(AuthContext);
   const [tipo, setTipo] = useState('natural');
   const [nombre, setNombre] = useState('');
   const [rut, setRut] = useState('');
-  const [correo, setCorreo] = useState('');
+  const [correo, setCorreo] = useState(usuario || '');
   const [dimensiones, setDimensiones] = useState('');
   const [cotizaciones, setCotizaciones] = useState([]);
 
@@ -50,6 +52,15 @@ function QuoteForm() {
     setRut(input);
   };
 
+  if (!usuario) {
+    return (
+      <section className="formulario-cotizacion">
+        <h2>Solicitar Cotización</h2>
+        <p>Debes iniciar sesión para enviar una cotización.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="formulario-cotizacion">
       <h2>Solicitar Cotización</h2>
@@ -82,6 +93,7 @@ function QuoteForm() {
           value={correo}
           onChange={(e) => setCorreo(e.target.value)}
           required
+          readOnly={!!usuario}
         />
 
         <label>Dimensiones del producto (opcional):</label>

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,16 @@
+import { createContext, useState } from 'react';
+
+export const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [usuario, setUsuario] = useState(null);
+
+  const login = (correo) => setUsuario(correo);
+  const logout = () => setUsuario(null);
+
+  return (
+    <AuthContext.Provider value={{ usuario, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,11 +4,14 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import { CarritoProvider } from './context/CarritoContext'; // <- importante
+import { AuthProvider } from './context/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <BrowserRouter>
-    <CarritoProvider>
-      <App />
-    </CarritoProvider>
+    <AuthProvider>
+      <CarritoProvider>
+        <App />
+      </CarritoProvider>
+    </AuthProvider>
   </BrowserRouter>
 );


### PR DESCRIPTION
## Summary
- create `AuthContext` to track logged-in user
- wrap app with `AuthProvider`
- add `/pago` route
- use context login in `Login` and restrict `QuoteForm` & `Pago`
- prefill email fields when logged in

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68521ebe5ba48325ac7186e7b93fe527