### PR TITLE
Require login before quoting or paying

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import './App.css';
 import Home from './Home';
 import Carrito from './Carrito';
 import Login from './Login'; // ✅ Importar Login
+import Pago from './Pago';
 
 function App() {
   return (
@@ -22,6 +23,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/carrito" element={<Carrito />} />
         <Route path="/login" element={<Login />} /> {/* ✅ Ruta funcional */}
+        <Route path="/pago" element={<Pago />} />
       </Routes>
     </div>
   );

--- a/src/Carrito.css
+++ b/src/Carrito.css
@@ -1,74 +1,99 @@
 .carrito-container {
-  padding: 3rem 2rem;
-  background-color: white;
-  max-width: 900px;
-  margin: 0 auto;
-  border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
-
-.tabla-carrito {
-  width: 100%;
-  border-collapse: collapse;
-  margin-bottom: 1.5rem;
-}
-
-.tabla-carrito th,
-.tabla-carrito td {
-  border: 1px solid #ddd;
-  padding: 0.75rem;
-  text-align: center;
-}
-
-.tabla-carrito th {
-  background-color: #f0f0f0;
-}
-
-.carrito-total {
-  text-align: right;
-}
-
-.carrito-total button {
-  background: var(--secondary);
-  color: white;
-  padding: 0.6rem 1.2rem;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  margin-top: 1rem;
-}
-.carrito-container {
   padding: 2rem;
   max-width: 900px;
-  margin: 0 auto;
-  background-color: #fff;
-  border-radius: 12px;
-  box-shadow: 0 0 12px rgba(0, 0, 0, 0.1);
+  margin: 2rem auto;
+  background: #fff;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  font-family: 'Segoe UI', sans-serif;
 }
 
-.tabla-carrito {
+.carrito-container h2 {
+  text-align: center;
+  margin-bottom: 2rem;
+  font-weight: 600;
+}
+
+.carrito-lista {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1.5rem;
+}
+
+.carrito-card {
+  background: var(--light-bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 1rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.carrito-card img {
   width: 100%;
-  border-collapse: collapse;
+  max-width: 150px;
   margin-bottom: 1rem;
 }
 
-.tabla-carrito th,
-.tabla-carrito td {
-  padding: 12px;
-  border: 1px solid #ddd;
-  text-align: center;
+.carrito-card h3 {
+  margin: 0.5rem 0;
+}
+
+.cantidad-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.carrito-card button {
+  background: #000;
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.carrito-card button:hover {
+  background: #333;
 }
 
 .carrito-total {
+  margin-top: 2rem;
   text-align: right;
 }
 
-.carrito-total button {
-  padding: 0.6rem 1.2rem;
+.acciones {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
   margin-top: 1rem;
-  background-color: #5b48f1;
-  color: white;
+}
+
+.carrito-total button {
+  background: #000;
+  color: #fff;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius);
+  padding: 0.6rem 1.2rem;
   cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.carrito-total button:hover {
+  background: #333;
+}
+
+.carrito-vacio {
+  text-align: center;
+  color: #555;
+}
+
+.carrito-vacio img {
+  width: 200px;
+  margin-bottom: 1rem;
 }

--- a/src/Carrito.jsx
+++ b/src/Carrito.jsx
@@ -18,42 +18,43 @@ function Carrito() {
       <h2>Carrito de Compras</h2>
 
       {carrito.length === 0 ? (
-        <p>Tu carrito está vacío.</p>
+        <div className="carrito-vacio">
+          <img
+            src="https://i.imgur.com/MT5QUBx.png"
+            alt="Carrito vacío"
+          />
+          <p>Tu carrito está vacío.</p>
+        </div>
       ) : (
         <>
-          <table className="tabla-carrito">
-            <thead>
-              <tr>
-                <th>Producto</th>
-                <th>Precio</th>
-                <th>Cantidad</th>
-                <th>Total</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {carrito.map((item) => (
-                <tr key={item.nombre}>
-                  <td>{item.nombre}</td>
-                  <td>${item.precio}</td>
-                  <td>
-                    <button onClick={() => cambiarCantidad(item.nombre, -1)}>-</button>
-                    <span style={{ margin: '0 8px' }}>{item.cantidad}</span>
-                    <button onClick={() => cambiarCantidad(item.nombre, 1)}>+</button>
-                  </td>
-                  <td>${item.precio * item.cantidad}</td>
-                  <td>
-                    <button onClick={() => eliminarProducto(item.nombre)}>Eliminar</button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <div className="carrito-lista">
+            {carrito.map((item) => (
+              <div className="carrito-card" key={item.nombre}>
+                <img
+                  src="https://via.placeholder.com/150?text=Caja"
+                  alt={item.nombre}
+                />
+                <h3>{item.nombre}</h3>
+                <p>${item.precio}</p>
+                <div className="cantidad-controls">
+                  <button onClick={() => cambiarCantidad(item.nombre, -1)}>-</button>
+                  <span>{item.cantidad}</span>
+                  <button onClick={() => cambiarCantidad(item.nombre, 1)}>+</button>
+                </div>
+                <p>Total: ${item.precio * item.cantidad}</p>
+                <button onClick={() => eliminarProducto(item.nombre)}>
+                  Eliminar
+                </button>
+              </div>
+            ))}
+          </div>
 
           <div className="carrito-total">
-            <p><strong>Total:</strong> ${total}</p>
+            <p>
+              <strong>Total:</strong> ${total}
+            </p>
 
-            <div style={{ display: 'flex', gap: '1rem', marginTop: '1rem' }}>
+            <div className="acciones">
               <button onClick={vaciarCarrito}>Vaciar Carrito</button>
 
               <Link to="/">
@@ -61,9 +62,7 @@ function Carrito() {
               </Link>
 
               <Link to="/pago">
-                <button style={{ backgroundColor: '#28a745', color: 'white' }}>
-                  Ir a Pagar
-                </button>
+                <button>Ir a Pagar</button>
               </Link>
             </div>
           </div>

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -1,25 +1,26 @@
-import { useState } from 'react';
+import { useState, useContext } from 'react';
+import { AuthContext } from './context/AuthContext';
 import './Login.css';
 
 function Login() {
+  const { usuario, login } = useContext(AuthContext);
   const [correo, setCorreo] = useState('');
   const [clave, setClave] = useState('');
-  const [logueado, setLogueado] = useState(false);
 
   const handleSubmit = (e) => {
     e.preventDefault();
 
     // Aquí podrías validar credenciales contra un backend más adelante
     if (correo && clave) {
-      setLogueado(true);
+      login(correo);
     }
   };
 
-  if (logueado) {
+  if (usuario) {
     return (
       <section className="login-container">
         <h2>Bienvenido</h2>
-        <p>Has iniciado sesión correctamente como <strong>{correo}</strong>.</p>
+        <p>Has iniciado sesión correctamente como <strong>{usuario}</strong>.</p>
       </section>
     );
   }

--- a/src/Pago.jsx
+++ b/src/Pago.jsx
@@ -1,13 +1,24 @@
 import { useContext, useState } from 'react';
 import { CarritoContext } from './context/CarritoContext';
+import { AuthContext } from './context/AuthContext';
 import './Pago.css'; // crea este archivo si quieres estilos personalizados
 
 function Pago() {
+  const { usuario } = useContext(AuthContext);
   const { carrito, vaciarCarrito } = useContext(CarritoContext);
   const [nombre, setNombre] = useState('');
   const [direccion, setDireccion] = useState('');
-  const [correo, setCorreo] = useState('');
+  const [correo, setCorreo] = useState(usuario || '');
   const [pedidoEnviado, setPedidoEnviado] = useState(false);
+
+  if (!usuario) {
+    return (
+      <section style={{ padding: '2rem' }}>
+        <h2>Proceso de Pago</h2>
+        <p>Debes iniciar sesión para completar el pago.</p>
+      </section>
+    );
+  }
 
   const total = carrito.reduce((acc, item) => acc + item.precio * item.cantidad, 0);
 
@@ -47,7 +58,13 @@ function Pago() {
         <input type="text" value={direccion} onChange={(e) => setDireccion(e.target.value)} required />
 
         <label>Correo electrónico:</label>
-        <input type="email" value={correo} onChange={(e) => setCorreo(e.target.value)} required />
+        <input
+          type="email"
+          value={correo}
+          onChange={(e) => setCorreo(e.target.value)}
+          required
+          readOnly={!!usuario}
+        />
 
         <button type="submit">Confirmar Pedido</button>
       </form>

--- a/src/QuoteForm.css
+++ b/src/QuoteForm.css
@@ -1,10 +1,10 @@
 .formulario-cotizacion {
   padding: 3rem 2rem;
-  background: white;
+  background: #fff;
   max-width: 600px;
   margin: 2rem auto;
-  border-radius: 12px;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
 }
 
 .formulario-cotizacion h2 {
@@ -15,25 +15,36 @@
 .formulario-cotizacion form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
+}
+
+.formulario-cotizacion label {
+  font-weight: 500;
+  margin-bottom: 0.25rem;
 }
 
 .formulario-cotizacion input,
 .formulario-cotizacion select {
-  padding: 0.7rem;
-  border-radius: 8px;
-  border: 1px solid #ccc;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid #ddd;
   font-size: 1rem;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .formulario-cotizacion button {
-  background: var(--secondary);
-  color: white;
+  background: var(--primary);
+  color: #fff;
   border: none;
   padding: 0.9rem;
   font-size: 1rem;
-  border-radius: 8px;
+  border-radius: var(--radius);
   cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.formulario-cotizacion button:hover {
+  background: #333;
 }
 
 .mensaje-enviado {

--- a/src/QuoteForm.jsx
+++ b/src/QuoteForm.jsx
@@ -1,9 +1,11 @@
 import { useState, useContext } from 'react';
 import { AuthContext } from './context/AuthContext';
+import { CarritoContext } from './context/CarritoContext';
 import './QuoteForm.css';
 
 function QuoteForm() {
   const { usuario } = useContext(AuthContext);
+  const { carrito } = useContext(CarritoContext);
   const [tipo, setTipo] = useState('natural');
   const [nombre, setNombre] = useState('');
   const [rut, setRut] = useState('');
@@ -11,8 +13,18 @@ function QuoteForm() {
   const [dimensiones, setDimensiones] = useState('');
   const [cotizaciones, setCotizaciones] = useState([]);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
+
+    if (!usuario) {
+      alert('Debes iniciar sesión para enviar la cotización');
+      return;
+    }
+
+    if (carrito.length === 0) {
+      alert('Tu carrito está vacío');
+      return;
+    }
 
     const nuevaCotizacion = {
       tipo,
@@ -20,15 +32,29 @@ function QuoteForm() {
       rut,
       correo,
       dimensiones,
+      carrito,
     };
 
-    setCotizaciones([...cotizaciones, nuevaCotizacion]);
+    try {
+      const resp = await fetch('http://localhost:3001/api/cotizacion', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(nuevaCotizacion),
+      });
 
-    // Limpiar campos
-    setNombre('');
-    setRut('');
-    setCorreo('');
-    setDimensiones('');
+      if (resp.ok) {
+        alert('Cotización enviada');
+        setCotizaciones([...cotizaciones, nuevaCotizacion]);
+        setNombre('');
+        setRut('');
+        setCorreo(usuario || '');
+        setDimensiones('');
+      } else {
+        alert('Error al enviar la cotización');
+      }
+    } catch {
+      alert('No se pudo conectar con el servidor');
+    }
   };
 
   // 👉 Formatea y limita el RUT (ej: 19342283-K)

--- a/src/QuoteForm.jsx
+++ b/src/QuoteForm.jsx
@@ -1,11 +1,13 @@
-import { useState } from 'react';
+import { useState, useContext } from 'react';
+import { AuthContext } from './context/AuthContext';
 import './QuoteForm.css';
 
 function QuoteForm() {
+  const { usuario } = useContext(AuthContext);
   const [tipo, setTipo] = useState('natural');
   const [nombre, setNombre] = useState('');
   const [rut, setRut] = useState('');
-  const [correo, setCorreo] = useState('');
+  const [correo, setCorreo] = useState(usuario || '');
   const [dimensiones, setDimensiones] = useState('');
   const [cotizaciones, setCotizaciones] = useState([]);
 
@@ -50,6 +52,15 @@ function QuoteForm() {
     setRut(input);
   };
 
+  if (!usuario) {
+    return (
+      <section className="formulario-cotizacion">
+        <h2>Solicitar Cotización</h2>
+        <p>Debes iniciar sesión para enviar una cotización.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="formulario-cotizacion">
       <h2>Solicitar Cotización</h2>
@@ -82,6 +93,7 @@ function QuoteForm() {
           value={correo}
           onChange={(e) => setCorreo(e.target.value)}
           required
+          readOnly={!!usuario}
         />
 
         <label>Dimensiones del producto (opcional):</label>

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,16 @@
+import { createContext, useState } from 'react';
+
+export const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [usuario, setUsuario] = useState(null);
+
+  const login = (correo) => setUsuario(correo);
+  const logout = () => setUsuario(null);
+
+  return (
+    <AuthContext.Provider value={{ usuario, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,11 +4,14 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import { CarritoProvider } from './context/CarritoContext'; // <- importante
+import { AuthProvider } from './context/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <BrowserRouter>
-    <CarritoProvider>
-      <App />
-    </CarritoProvider>
+    <AuthProvider>
+      <CarritoProvider>
+        <App />
+      </CarritoProvider>
+    </AuthProvider>
   </BrowserRouter>
 );


### PR DESCRIPTION
## Summary
- create `AuthContext` to track logged-in user
- wrap app with `AuthProvider`
- add `/pago` route
- use context login in `Login` and restrict `QuoteForm` & `Pago`
- prefill email fields when logged in

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68521ebe5ba48325ac7186e7b93fe527